### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo


### PR DESCRIPTION
Bump GitHub Actions versions
  ```diff
  diff --git a/.github/workflows/cargo_update.yml b/.github/workflows/cargo_update.yml
index fee44c0..389ca60 100644
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
diff --git a/.github/workflows/core.yml b/.github/workflows/core.yml
index b216fea..3aa48a3 100644
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
diff --git a/.github/workflows/machete.yml b/.github/workflows/machete.yml
index 8bb9c29..1589c38 100644
--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.cargo
  ```