### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -110,7 +110,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: coverage-report
           path: ./tarpaulin-report.html


### PR DESCRIPTION
Bump GitHub Actions versions
  ```diff
  diff --git a/.github/workflows/core.yml b/.github/workflows/core.yml
index 3aa48a3..5a93ce1 100644
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -110,7 +110,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: coverage-report
           path: ./tarpaulin-report.html
\ No newline at end of file
  ```