### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo


### PR DESCRIPTION
Bump GitHub Actions versions
  ```diff
  diff --git a/.github/workflows/cargo_update.yml b/.github/workflows/cargo_update.yml
index 389ca60..b034998 100644
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
diff --git a/.github/workflows/core.yml b/.github/workflows/core.yml
index 5a93ce1..1500da1 100644
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
diff --git a/.github/workflows/machete.yml b/.github/workflows/machete.yml
index 1589c38..5fc0320 100644
--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.1
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo
  ```