### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -110,7 +110,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: coverage-report
           path: ./tarpaulin-report.html

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo


### PR DESCRIPTION
Bump GitHub Actions versions
  ```diff
  diff --git a/.github/workflows/cargo_update.yml b/.github/workflows/cargo_update.yml
index b034998..c7c8a45 100644
--- a/.github/workflows/cargo_update.yml
+++ b/.github/workflows/cargo_update.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
diff --git a/.github/workflows/core.yml b/.github/workflows/core.yml
index 1500da1..eec13a9 100644
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
@@ -110,7 +110,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: coverage-report
           path: ./tarpaulin-report.html
\ No newline at end of file
diff --git a/.github/workflows/machete.yml b/.github/workflows/machete.yml
index 5fc0320..40ce477 100644
--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Cargo Dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.cargo
  ```